### PR TITLE
Allow longer chat messages, add maxlength to textarea

### DIFF
--- a/chatboxPage.php
+++ b/chatboxPage.php
@@ -9,9 +9,9 @@
                 </div>
                 <div class="card-body">
                     <div class="chatbox-messages" id="chatbox-messages">
-                    </div> 
+                    </div>
                     <div class="form-outline">
-                        <textarea class="form-control" id="chatboxMessage" rows="4"></textarea>
+                        <textarea class="form-control" id="chatboxMessage" rows="4" maxlength="255"></textarea>
                         <label class="form-label" for="textAreaExample">Nachricht</label>
                     </div>
                     <button type="button" class="btn btn-outline-secondary ui-button mb-2" onclick="enterChatboxMessage(true)">

--- a/flugplanung.sql
+++ b/flugplanung.sql
@@ -29,7 +29,7 @@ SET time_zone = "+00:00";
 
 CREATE TABLE `chatbox` (
   `pilot_id` int(11) DEFAULT NULL,
-  `text` varchar(128) DEFAULT NULL,
+  `text` varchar(255) DEFAULT NULL,
   `datetime` timestamp NOT NULL DEFAULT current_timestamp()
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 


### PR DESCRIPTION
Using more than 128 characters caused an error, the message was not saved and the user did get no information about that.

Now longer messages are possible and the form blocks adding more text.