### PR TITLE
Work around potential webserver JSON issue

### DIFF
--- a/js/wunschliste.js
+++ b/js/wunschliste.js
@@ -45,7 +45,12 @@ function getUserWuensche() {
         type: 'GET',
         data: { pilot_id: User_Information.pilot_id, startDate: startDate, endDate: endDate },
         success: function (data) {
-            populateWuenscheValues(JSON.parse(data));
+            if (Array.isArray(data)) {
+                populateWuenscheValues(data);
+            } else {
+                console.log('data should be returned as array already!');
+                populateWuenscheValues(JSON.parse(data));
+            }
         },
         error: function (xhr, status, error) {
             console.log(xhr);


### PR DESCRIPTION
The JS returned should (like for all other requests) already be an array when it is being passed to `success`. If the webserver does not return `application/json` as the `Content-Type` this is the case – but all other places seem to work fine?